### PR TITLE
Fixed typo that caused cartographer node to die when using 2d-depth camera

### DIFF
--- a/cartographer_turtlebot/configuration_files/turtlebot_depth_camera_2d.lua
+++ b/cartographer_turtlebot/configuration_files/turtlebot_depth_camera_2d.lua
@@ -36,7 +36,7 @@ options = {
 
 MAP_BUILDER.use_trajectory_builder_2d = true
 
-TRAJECTORY_BUILDER_2D.laser_min_range = 0.1,
+TRAJECTORY_BUILDER_2D.laser_min_range = 0.1
 TRAJECTORY_BUILDER_2D.laser_max_range = 4.0
 TRAJECTORY_BUILDER_2D.laser_missing_echo_ray_length = 2.0
 TRAJECTORY_BUILDER_2D.use_imu_data = true

--- a/cartographer_turtlebot/configuration_files/turtlebot_depth_camera_2d.lua
+++ b/cartographer_turtlebot/configuration_files/turtlebot_depth_camera_2d.lua
@@ -37,8 +37,8 @@ options = {
 MAP_BUILDER.use_trajectory_builder_2d = true
 
 TRAJECTORY_BUILDER_2D.laser_min_range = 0.1,
-TRAJECTORY_BUILDER_2D.laser_max_range = 4.,
-TRAJECTORY_BUILDER_2D.laser_missing_echo_ray_length = 2.,
+TRAJECTORY_BUILDER_2D.laser_max_range = 4.0
+TRAJECTORY_BUILDER_2D.laser_missing_echo_ray_length = 2.0
 TRAJECTORY_BUILDER_2D.use_imu_data = true
 TRAJECTORY_BUILDER_2D.use_online_correlative_scan_matching = true
 TRAJECTORY_BUILDER_2D.motion_filter.max_time_seconds = 0.25

--- a/cartographer_turtlebot/configuration_files/turtlebot_urg_lidar_2d.lua
+++ b/cartographer_turtlebot/configuration_files/turtlebot_urg_lidar_2d.lua
@@ -36,9 +36,9 @@ options = {
 
 MAP_BUILDER.use_trajectory_builder_2d = true
 
-TRAJECTORY_BUILDER_2D.laser_min_range = 0.1,
-TRAJECTORY_BUILDER_2D.laser_max_range = 8.,
-TRAJECTORY_BUILDER_2D.laser_missing_echo_ray_length = 5.,
+TRAJECTORY_BUILDER_2D.laser_min_range = 0.1
+TRAJECTORY_BUILDER_2D.laser_max_range = 8.
+TRAJECTORY_BUILDER_2D.laser_missing_echo_ray_length = 5.
 TRAJECTORY_BUILDER_2D.use_imu_data = true
 TRAJECTORY_BUILDER_2D.use_online_correlative_scan_matching = true
 TRAJECTORY_BUILDER_2D.motion_filter.max_angle_radians = math.rad(0.1)


### PR DESCRIPTION
Lua configuration file had a typo which caused it to crash when it was run.