### PR TITLE
'rosdep init' needs 'sudo'.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,7 +55,9 @@ using `Ninja <https://ninja-build.org>`_.
     wstool update -t src
 
     # Install deb dependencies.
-    rosdep init
+    # The command 'sudo rosdep init' will print an error if you have already
+    # executed it since installing ROS. This error can be ignored.
+    sudo rosdep init
     rosdep update
     rosdep install --from-paths src --ignore-src --rosdistro=${ROS_DISTRO} -y
 


### PR DESCRIPTION
Fixes #67.