### PR TITLE
Set the horizontal angular velocity to zero

### DIFF
--- a/cartographer_turtlebot/cartographer_turtlebot/flat_world_imu_node_main.cc
+++ b/cartographer_turtlebot/cartographer_turtlebot/flat_world_imu_node_main.cc
@@ -47,6 +47,8 @@ int main(int argc, char** argv) {
               sensor_msgs::Imu imu_out = *imu_in;
               // TODO(damonkohler): This relies on the z-axis alignment of the
               // IMU with the Kobuki base.
+              imu_out.angular_velocity.x = 0.;
+              imu_out.angular_velocity.y = 0.;
               imu_out.linear_acceleration.x = 0.;
               imu_out.linear_acceleration.y = 0.;
               imu_out.linear_acceleration.z = kFakeGravity;


### PR DESCRIPTION
I think the angular velocity regarding to x and y axis is useless, in the case of 2d mapping.
Maybe  these values  are omitted in the latest cartographer if [```use_trajectory_builder_2d ```](https://github.com/googlecartographer/cartographer_turtlebot/blob/master/cartographer_turtlebot/configuration_files/turtlebot_depth_camera_2d.lua#L45) is true. 

However, we are trying to use the debianized cartographer in ros kinetic distro, which is based on version [0.2.0](https://github.com/ros/rosdistro/blob/master/kinetic/distribution.yaml#L952-L977), and I found that the horizontal angular velocity effects significantly on the localization as shown in the following GIF.
![old_cartographer_without_acml](https://user-images.githubusercontent.com/3666095/42203475-d03aa8fa-7ed9-11e8-8c41-c55beee0910a.gif)

After applying this commit, the localization is improved a lot as shown in the following GIF.
![old_cartographer_without_xy_gyro](https://user-images.githubusercontent.com/3666095/42203581-3547e8b6-7eda-11e8-96b7-9dafdb9b6513.gif)

Please think about to merge this commit.

